### PR TITLE
upgrade scp2 version to v0.5.0 to support port parsing, and update or…

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,16 @@ var client = require('scp2');
 
 function WebpackSftpClient(options) {
     this.options = options;
+    var self = this;
+
+    var remotePath = self.options.remotePath;
+    var path = self.options.path;
+    var username = self.options.username;
+    var host = self.options.host;
+    var password = self.options.password;
+    var port = self.options.port || '22';
+
+        console.log(username + ':' + password + '@' + host + ':' + port + ':' + remotePath);
 }
 
 WebpackSftpClient.prototype.apply = function(compiler) {
@@ -24,9 +34,10 @@ WebpackSftpClient.prototype.apply = function(compiler) {
         var username = self.options.username;
         var host = self.options.host;
         var password = self.options.password;
+        var port = self.options.port || '22';
 
         client.scp(self.options.path,
-            username + ':' + password + '@' + host + ':' + remotePath,
+            username + ':' + password + '@' + host + ':' + port + ':' + remotePath,
             function (err) {
                 if (err) {
                     console.log(err);
@@ -38,6 +49,15 @@ WebpackSftpClient.prototype.apply = function(compiler) {
 
     });
 };
+
+new WebpackSftpClient({
+    port: '55',
+    host: 'exmaple.com',
+    username: 'root',
+    password: 'password',
+    path: './build/',
+    remotePath: '/data/website/demo/'
+});
 
 
 module.exports = WebpackSftpClient;

--- a/index.js
+++ b/index.js
@@ -11,16 +11,6 @@ var client = require('scp2');
 
 function WebpackSftpClient(options) {
     this.options = options;
-    var self = this;
-
-    var remotePath = self.options.remotePath;
-    var path = self.options.path;
-    var username = self.options.username;
-    var host = self.options.host;
-    var password = self.options.password;
-    var port = self.options.port || '22';
-
-        console.log(username + ':' + password + '@' + host + ':' + port + ':' + remotePath);
 }
 
 WebpackSftpClient.prototype.apply = function(compiler) {
@@ -49,15 +39,5 @@ WebpackSftpClient.prototype.apply = function(compiler) {
 
     });
 };
-
-new WebpackSftpClient({
-    port: '55',
-    host: 'exmaple.com',
-    username: 'root',
-    password: 'password',
-    path: './build/',
-    remotePath: '/data/website/demo/'
-});
-
 
 module.exports = WebpackSftpClient;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/sqhtiamo/webpack-sftp-client#readme",
   "dependencies": {
-    "scp2": "^0.4.0"
+    "scp2": "^0.5.0"
   }
 }


### PR DESCRIPTION
original version scp2 v0.4.0 has parsing remote address error (**can't parse port issue, the v.0.5.0 fixed it**), so i upgrade it to v0.5.0, and your original code doesn't assign port variable into remote address, i refined it, please take a look.
